### PR TITLE
Target es5

### DIFF
--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -6,7 +6,7 @@ import {
     TimeAvailability,
     Schedule, ScheduleSpecificDate, Interval
 } from '../index.d';
-import { cloneDeep, omit} from 'lodash';
+import {cloneDeep, omit} from 'lodash';
 import Moment = moment.Moment;
 
 export class Scheduler {

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -396,7 +396,7 @@ export class Scheduler {
     }
 
     public getIntersection(p: IntersectParams): Availability {
-        const params: AvailabilityParams = <AvailabilityParams>assignIn(
+        const params: AvailabilityParams = <AvailabilityParams> assignIn(
             { schedule: null },
             cloneDeep(omit(p, ['schedules']))
         );

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -6,7 +6,7 @@ import {
     TimeAvailability,
     Schedule, ScheduleSpecificDate, Interval
 } from '../index.d';
-import {cloneDeep, omit} from 'lodash';
+import { assignIn, cloneDeep, omit} from 'lodash';
 import Moment = moment.Moment;
 
 export class Scheduler {
@@ -396,7 +396,7 @@ export class Scheduler {
     }
 
     public getIntersection(p: IntersectParams): Availability {
-        const params: AvailabilityParams = <AvailabilityParams> (<any>Object).assign(
+        const params: AvailabilityParams = <AvailabilityParams>assignIn(
             { schedule: null },
             cloneDeep(omit(p, ['schedules']))
         );

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -396,7 +396,7 @@ export class Scheduler {
     }
 
     public getIntersection(p: IntersectParams): Availability {
-        const params: AvailabilityParams = <AvailabilityParams> Object.assign(
+        const params: AvailabilityParams = <AvailabilityParams> (<any>Object).assign(
             { schedule: null },
             cloneDeep(omit(p, ['schedules']))
         );

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -6,7 +6,7 @@ import {
     TimeAvailability,
     Schedule, ScheduleSpecificDate, Interval
 } from '../index.d';
-import { assignIn, cloneDeep, omit} from 'lodash';
+import { cloneDeep, omit} from 'lodash';
 import Moment = moment.Moment;
 
 export class Scheduler {
@@ -396,10 +396,10 @@ export class Scheduler {
     }
 
     public getIntersection(p: IntersectParams): Availability {
-        const params: AvailabilityParams = <AvailabilityParams> assignIn(
-            { schedule: null },
-            cloneDeep(omit(p, ['schedules']))
-        );
+        const params: AvailabilityParams = {
+            ...{ schedule: null },
+            ...<AvailabilityParams> cloneDeep(omit(p, ['schedules']))
+        };
         const availabilities: Availability[] = [];
         for (const schedule of p.schedules) {
             params.schedule = schedule;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ES5",
     "module": "commonjs",
     "outDir": "./dist/",
     "sourceMap": true,


### PR DESCRIPTION
Hi there, this is my first attempt at a contribution. Please feel free to let me know exactly what I can do better if I've done anything wrong!

This is the simplest way I could find to change the target to ES5. Since `Object`'s prototype doesn't have `assign` in ES5, I've opted to import `assignIn` from lodash.

The code compiles and the tests pass. There are deprecations and vulnerabilities in the compilation process which I've ignored as they seem out of scope for this issue.